### PR TITLE
view handler: update `halt`to not break flexible args behavior

### DIFF
--- a/lib/deas-json/view_handler.rb
+++ b/lib/deas-json/view_handler.rb
@@ -4,6 +4,10 @@ module Deas::Json
 
   module ViewHandler
 
+    DEF_STATUS  = nil
+    DEF_HEADERS = {}.freeze
+    DEF_BODY    = '{}'.freeze
+
     def self.included(klass)
       klass.class_eval do
         include Deas::ViewHandler
@@ -23,7 +27,13 @@ module Deas::Json
       # Some http clients will error when trying to parse an empty body when the
       # content type is 'json'.  This will default the body to a string that
       # can be parsed to an empty json object
-      def halt(status, headers = {}, body = '{}')
+      def halt(*args)
+        super(DEF_STATUS, DEF_HEADERS, DEF_BODY) if args.empty?
+        body, headers, status = [
+          !args.last.kind_of?(::Hash) && !args.last.kind_of?(::Integer) ? args.pop : DEF_BODY,
+          args.last.kind_of?(::Hash) ? args.pop : DEF_HEADERS,
+          args.first.kind_of?(::Integer) ? args.first : DEF_STATUS
+        ]
         super(status, headers, body)
       end
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -17,6 +17,12 @@ module Deas::Json::ViewHandler
       assert_includes Deas::ViewHandler, subject
     end
 
+    should "know its default status, headers and body values" do
+      assert_equal nil,      subject::DEF_STATUS
+      assert_equal Hash.new, subject::DEF_HEADERS
+      assert_equal '{}',     subject::DEF_BODY
+    end
+
   end
 
   class InitTests < UnitTests
@@ -33,16 +39,7 @@ module Deas::Json::ViewHandler
       assert_equal :json, subject.content_type.value
     end
 
-    should "default its body and headers if not provided" do
-      @handler.status = Factory.integer
-      response = @runner.run
-
-      assert_equal @handler.status, response.status
-      assert_equal({},              response.headers)
-      assert_equal '{}',            response.body
-    end
-
-    should "allow halting with a body and headers" do
+    should "use all given args" do
       @handler.status  = Factory.integer
       @handler.headers = { Factory.string => Factory.string }
       @handler.body    = Factory.text
@@ -51,6 +48,71 @@ module Deas::Json::ViewHandler
       assert_equal @handler.status,  response.status
       assert_equal @handler.headers, response.headers
       assert_equal @handler.body,    response.body
+    end
+
+    should "default its status, headers and body if not provided" do
+      response = @runner.run
+
+      assert_equal DEF_STATUS,  response.status
+      assert_equal DEF_HEADERS, response.headers
+      assert_equal DEF_BODY,    response.body
+    end
+
+    should "default its headers and body if not provided" do
+      @handler.status = Factory.integer
+      response = @runner.run
+
+      assert_equal @handler.status, response.status
+      assert_equal DEF_HEADERS,     response.headers
+      assert_equal DEF_BODY,        response.body
+    end
+
+    should "default its status and body if not provided" do
+      @handler.headers = { Factory.string => Factory.string }
+      response = @runner.run
+
+      assert_equal DEF_STATUS,       response.status
+      assert_equal @handler.headers, response.headers
+      assert_equal DEF_BODY,         response.body
+    end
+
+    should "default its status and headers if not provided" do
+      @handler.body = Factory.text
+      response = @runner.run
+
+      assert_equal DEF_STATUS,    response.status
+      assert_equal DEF_HEADERS,   response.headers
+      assert_equal @handler.body, response.body
+    end
+
+    should "default its status if not provided" do
+      @handler.headers = { Factory.string => Factory.string }
+      @handler.body = Factory.text
+      response = @runner.run
+
+      assert_equal DEF_STATUS,       response.status
+      assert_equal @handler.headers, response.headers
+      assert_equal @handler.body,    response.body
+    end
+
+    should "default its headers if not provided" do
+      @handler.status = Factory.integer
+      @handler.body = Factory.text
+      response = @runner.run
+
+      assert_equal @handler.status, response.status
+      assert_equal DEF_HEADERS,     response.headers
+      assert_equal @handler.body,   response.body
+    end
+
+    should "default its body if not provided" do
+      @handler.status  = Factory.integer
+      @handler.headers = { Factory.string => Factory.string }
+      response = @runner.run
+
+      assert_equal @handler.status,  response.status
+      assert_equal @handler.headers, response.headers
+      assert_equal DEF_BODY,         response.body
     end
 
   end


### PR DESCRIPTION
This underlying `halt` on a deas' view handler allows for multiple
combinations of arguments to be passes with fallbacks to intelligent
defaults.  The previous implementation essentially forced sending
args in a specific order.  This mean you couldn't call `halt` like
`halt(404, 'unknown resource')` using a json view handler.

This was not the original intent.  The intent is that you can use
`halt` just as you would on a normal view handler.  This change
preserves that original intent, with fallbacks to json-intelligent
defaults for args that are not specified.

@jcredding ready for review.
