### PR TITLE
bring in much-plugin; move init behavior into a before init hook

### DIFF
--- a/deas-json.gemspec
+++ b/deas-json.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.14"])
 
-  gem.add_dependency("deas", ["~> 0.34"])
+  gem.add_dependency("deas",        ["~> 0.34"])
+  gem.add_dependency("much-plugin", ["~> 0.1"])
 
 end

--- a/lib/deas-json/view_handler.rb
+++ b/lib/deas-json/view_handler.rb
@@ -1,26 +1,23 @@
 require 'deas/view_handler'
+require 'much-plugin'
 
 module Deas::Json
 
   module ViewHandler
+    include MuchPlugin
 
     DEF_STATUS  = nil
     DEF_HEADERS = {}.freeze
     DEF_BODY    = '{}'.freeze
 
-    def self.included(klass)
-      klass.class_eval do
-        include Deas::ViewHandler
-        include InstanceMethods
-      end
+    plugin_included do
+      include Deas::ViewHandler
+      include InstanceMethods
+
+      before_init{ content_type :json }
     end
 
     module InstanceMethods
-
-      def initialize(*args)
-        super(*args)
-        content_type :json
-      end
 
       private
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -13,6 +13,10 @@ module Deas::Json::ViewHandler
     end
     subject{ @handler_class }
 
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Deas::Json::ViewHandler
+    end
+
     should "be a deas view handler" do
       assert_includes Deas::ViewHandler, subject
     end


### PR DESCRIPTION
In deas view handlers, it is better to _not_ override the initializers
and instead use the callback system to attach init behavior.  However,
this is dangerous to do in included methods as that every time the
mixin is included (even on a receiver it was already included on)
this method will execute.  This leaves the possibility of adding
multiple of the same deas view handler callbacks.

This brings in the much-plugin gem when ensures the plugin included
procs are only executed once per receiver and then replaces the
initializer override with a before init callback.

There are no behavior or test changes - just a cleanup to more
properly bind this behavior to deas json view handlers.

@jcredding ready for review.
