### PR TITLE
get working in modern ruby versions

### DIFF
--- a/deas-json.gemspec
+++ b/deas-json.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("deas",        ["~> 0.40.0"])
-  gem.add_dependency("much-plugin", ["~> 0.1.0"])
+  gem.add_dependency("deas",        ["~> 0.41.0"])
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,3 +8,12 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 require 'pry'
 
 require 'test/support/factory'
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get up to convention for working in modern ruby versions.
This includes backfilling Array#sample so it works in 1.8.7.

@jcredding ready for review.
