### PR TITLE
call the `body` helper when halting

### DIFF
--- a/deas-json.gemspec
+++ b/deas-json.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.16.3"])
 
-  gem.add_dependency("deas",        ["~> 0.43.3"])
+  gem.add_dependency("deas",        ["~> 0.43.4"])
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
 
 end

--- a/lib/deas-json/view_handler.rb
+++ b/lib/deas-json/view_handler.rb
@@ -23,12 +23,13 @@ module Deas::Json
 
       # Some http clients will error when trying to parse an empty body when the
       # content type is 'json'.  This will default the body to a string that
-      # can be parsed to an empty json object
+      # can be parsed to an empty json object.
+      # We call the `body` helper method to make sure it adhere's to the Rack spec
       def halt(*args)
         super(
           args.first.instance_of?(::Fixnum) ? args.shift : DEF_STATUS,
           args.first.kind_of?(::Hash) ? args.shift : DEF_HEADERS,
-          args.first.respond_to?(:each) ? args.shift : DEF_BODY
+          body(!args.first.to_s.empty? ? args.shift : DEF_BODY)
         )
       end
 

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -57,12 +57,21 @@ module Deas::Json::ViewHandler
       assert_equal @body,    response.body
     end
 
+    should "should adhere to the rack spec for its body" do
+      @handler.halt_args = [@status, @headers, @body.first]
+      response = @runner.run
+
+      assert_equal @status,  response.status
+      assert_equal @headers, response.headers
+      assert_equal @body,    response.body
+    end
+
     should "default its status, headers and body if not provided" do
       response = @runner.run
 
       assert_equal DEF_STATUS,  response.status
       assert_equal DEF_HEADERS, response.headers
-      assert_equal DEF_BODY,    response.body
+      assert_equal [DEF_BODY],  response.body
     end
 
     should "default its headers and body if not provided" do
@@ -71,7 +80,7 @@ module Deas::Json::ViewHandler
 
       assert_equal @status,     response.status
       assert_equal DEF_HEADERS, response.headers
-      assert_equal DEF_BODY,    response.body
+      assert_equal [DEF_BODY],  response.body
     end
 
     should "default its status and body if not provided" do
@@ -80,7 +89,7 @@ module Deas::Json::ViewHandler
 
       assert_equal DEF_STATUS, response.status
       assert_equal @headers,   response.headers
-      assert_equal DEF_BODY,   response.body
+      assert_equal [DEF_BODY], response.body
     end
 
     should "default its status and headers if not provided" do
@@ -111,12 +120,12 @@ module Deas::Json::ViewHandler
     end
 
     should "default its body if not provided" do
-      @handler.halt_args = [@status, @headers]
+      @handler.halt_args = [@status, @headers, [nil, ''].sample]
       response = @runner.run
 
-      assert_equal @status,  response.status
-      assert_equal @headers, response.headers
-      assert_equal DEF_BODY, response.body
+      assert_equal @status,    response.status
+      assert_equal @headers,   response.headers
+      assert_equal [DEF_BODY], response.body
     end
 
   end


### PR DESCRIPTION
This ensures that whatever body value we halt with will adhere to
Rack's spec in the response.  This involved also forcing the
latest Deas version (0.43.4) which similarly ensures halt bodies
adhere to Rack's spec.

I also changed the check for whether to send the default body or
not to be based on only if it is given an "empty" body.  I chose
to just test for super obvious stuff for now: `nil` or `""`.  The
goal here is to always return something that is valid json if at
all possible.

@jcredding ready for review.