### PR TITLE
don't call Deas' body helper when halting

### DIFF
--- a/lib/deas-json/view_handler.rb
+++ b/lib/deas-json/view_handler.rb
@@ -24,12 +24,11 @@ module Deas::Json
       # Some http clients will error when trying to parse an empty body when the
       # content type is 'json'.  This will default the body to a string that
       # can be parsed to an empty json object.
-      # We call the `body` helper method to make sure it adhere's to the Rack spec
       def halt(*args)
         super(
           args.first.instance_of?(::Fixnum) ? args.shift : DEF_STATUS,
-          args.first.kind_of?(::Hash) ? args.shift : DEF_HEADERS,
-          body(!args.first.to_s.empty? ? args.shift : DEF_BODY)
+          args.first.kind_of?(::Hash)       ? args.shift : DEF_HEADERS,
+          !args.first.to_s.empty?           ? args.shift : DEF_BODY
         )
       end
 


### PR DESCRIPTION
Deas already handles this for you in its `halt` method.  This
supers to that method so it takes care of it for us.  This reverts
part of the work in PR 6.

I noticed this when I went to put Deas-Json in one of our apps and
saw errors come up in cases where we set a custom body using `body`
before halting.  I've updated the test suite to account for this
case as well.

See #6 for reference.

@jcredding ready for review.