### PR TITLE
switch to using Deas' new default response handler API

### DIFF
--- a/deas-json.gemspec
+++ b/deas-json.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.16.3"])
+  gem.add_development_dependency("assert",           ["~> 2.16.3"])
+  gem.add_development_dependency("assert-rack-test", ["~> 1.0.5"])
 
-  gem.add_dependency("deas",        ["~> 0.43.4"])
+  gem.add_dependency("deas",        ["~> 0.43.5"])
   gem.add_dependency("much-plugin", ["~> 0.2.0"])
 
 end

--- a/lib/deas-json/view_handler.rb
+++ b/lib/deas-json/view_handler.rb
@@ -6,33 +6,13 @@ module Deas::Json
   module ViewHandler
     include MuchPlugin
 
-    DEF_STATUS  = 200.freeze
-    DEF_HEADERS = {}.freeze
-    DEF_BODY    = '{}'.freeze
-
     plugin_included do
       include Deas::ViewHandler
-      include InstanceMethods
+
+      default_status 200
+      default_body   ['{}']
 
       before_init{ content_type('.json', 'charset' => 'utf-8') }
-    end
-
-    module InstanceMethods
-
-      private
-
-      # Some http clients will error when trying to parse an empty body when the
-      # content type is 'json'.  This will default the body to a string that
-      # can be parsed to an empty json object.
-      # We call the `body` helper method to make sure it adhere's to the Rack spec
-      def halt(*args)
-        super(
-          args.first.instance_of?(::Fixnum) ? args.shift : DEF_STATUS,
-          args.first.kind_of?(::Hash) ? args.shift : DEF_HEADERS,
-          body(!args.first.to_s.empty? ? args.shift : DEF_BODY)
-        )
-      end
-
     end
 
   end

--- a/test/system/rack_tests.rb
+++ b/test/system/rack_tests.rb
@@ -1,0 +1,85 @@
+require 'assert'
+require 'deas-json'
+
+require 'assert-rack-test'
+require 'deas'
+
+module Deas::Json
+
+  class RackTestsContext < Assert::Context
+    include Assert::Rack::Test
+
+    def app; @app; end
+  end
+
+  class RackTests < RackTestsContext
+    desc "a Deas server rack app"
+    setup do
+      @status_val = Factory.integer
+      @body_val   = Factory.text
+
+      @app = DeasTestServer.new
+    end
+
+    should "use given status/body values" do
+      get '/test.json', {
+        'status_val' => @status_val,
+        'body_val'   => @body_val
+      }
+
+      assert_equal @status_val, last_response.status
+      assert_equal @body_val,   last_response.body
+    end
+
+    should "default its status and body if not provided" do
+      get '/test.json'
+
+      assert_equal TestJsonHandler.default_status,     last_response.status
+      assert_equal TestJsonHandler.default_body.first, last_response.body
+    end
+
+    should "default its body if not provided" do
+      get '/test.json', {
+        'status_val' => @status_val
+      }
+
+      assert_equal @status_val,                        last_response.status
+      assert_equal TestJsonHandler.default_body.first, last_response.body
+    end
+
+    should "default its status if not provided" do
+      get '/test.json', {
+        'body_val' => @body_val
+      }
+
+      assert_equal TestJsonHandler.default_status, last_response.status
+      assert_equal @body_val,                      last_response.body
+    end
+
+  end
+
+end
+
+class DeasTestServer
+  include Deas::Server
+
+  router do
+    get '/test.json', 'TestJsonHandler'
+  end
+
+end
+
+class TestJsonHandler
+  include Deas::Json::ViewHandler
+
+  attr_accessor :halt_args
+
+  def run!
+    halt *([
+      (params['status_val'].to_i if params['status_val']),
+      params['body_val']
+    ].compact)
+  end
+
+end
+

--- a/test/unit/view_handler_tests.rb
+++ b/test/unit/view_handler_tests.rb
@@ -20,10 +20,9 @@ module Deas::Json::ViewHandler
       assert_includes Deas::ViewHandler, subject
     end
 
-    should "know its default status, headers and body values" do
-      assert_equal 200,      subject::DEF_STATUS
-      assert_equal Hash.new, subject::DEF_HEADERS
-      assert_equal '{}',     subject::DEF_BODY
+    should "override the default status and body values" do
+      assert_equal 200,    subject.default_status
+      assert_equal ['{}'], subject.default_body
     end
 
   end
@@ -33,10 +32,6 @@ module Deas::Json::ViewHandler
 
     desc "when init"
     setup do
-      @status  = Factory.integer
-      @headers = { Factory.string => Factory.string }
-      @body    = [Factory.text]
-
       @runner  = test_runner(@handler_class)
       @handler = @runner.handler
     end
@@ -47,95 +42,6 @@ module Deas::Json::ViewHandler
       exp = { 'charset' => 'utf-8' }
       assert_equal exp, subject.content_type_args.params
     end
-
-    should "use all given args" do
-      @handler.halt_args = [@status, @headers, @body]
-      response = @runner.run
-
-      assert_equal @status,  response.status
-      assert_equal @headers, response.headers
-      assert_equal @body,    response.body
-    end
-
-    should "should adhere to the rack spec for its body" do
-      @handler.halt_args = [@status, @headers, @body.first]
-      response = @runner.run
-
-      assert_equal @status,  response.status
-      assert_equal @headers, response.headers
-      assert_equal @body,    response.body
-    end
-
-    should "default its status, headers and body if not provided" do
-      response = @runner.run
-
-      assert_equal DEF_STATUS,  response.status
-      assert_equal DEF_HEADERS, response.headers
-      assert_equal [DEF_BODY],  response.body
-    end
-
-    should "default its headers and body if not provided" do
-      @handler.halt_args = [@status]
-      response = @runner.run
-
-      assert_equal @status,     response.status
-      assert_equal DEF_HEADERS, response.headers
-      assert_equal [DEF_BODY],  response.body
-    end
-
-    should "default its status and body if not provided" do
-      @handler.halt_args = [@headers]
-      response = @runner.run
-
-      assert_equal DEF_STATUS, response.status
-      assert_equal @headers,   response.headers
-      assert_equal [DEF_BODY], response.body
-    end
-
-    should "default its status and headers if not provided" do
-      @handler.halt_args = [@body]
-      response = @runner.run
-
-      assert_equal DEF_STATUS,  response.status
-      assert_equal DEF_HEADERS, response.headers
-      assert_equal @body,       response.body
-    end
-
-    should "default its status if not provided" do
-      @handler.halt_args = [@headers, @body]
-      response = @runner.run
-
-      assert_equal DEF_STATUS, response.status
-      assert_equal @headers,   response.headers
-      assert_equal @body,      response.body
-    end
-
-    should "default its headers if not provided" do
-      @handler.halt_args = [@status, @body]
-      response = @runner.run
-
-      assert_equal @status,     response.status
-      assert_equal DEF_HEADERS, response.headers
-      assert_equal @body,       response.body
-    end
-
-    should "default its body if not provided" do
-      @handler.halt_args = [@status, @headers, [nil, ''].sample]
-      response = @runner.run
-
-      assert_equal @status,    response.status
-      assert_equal @headers,   response.headers
-      assert_equal [DEF_BODY], response.body
-    end
-
-  end
-
-  class TestJsonHandler
-    include Deas::Json::ViewHandler
-
-    attr_accessor :halt_args
-
-    def run!; halt *(@halt_args || []).dup; end
 
   end
 


### PR DESCRIPTION
This is Deas' new way of letting handlers override the default
response values on a per-handler basis.  Now, Deas-Json's view
handler defaults the status and body and this applies whether
`halt` is used or not.  This is a more formal, thorough, and
universal way for Deas-Json to change the defaults and ensure they
are used in the absence of any instance specified status/body.

The goal of doing this is unchanged: to provide a valid empty
json object body if no formal body is specified so that browsers
and client side js doesn't error trying to parse json responses.
This only changes the manner used to accomplish this goal.

Note: this switched to adding some system tests to further and
more thoroughly test that responses were being defaulted correctly.
With the simpler handler implementation, its unit tests felt a
little wanting.

See https://github.com/redding/deas/pull/247 for reference.

@jcredding ready for review.